### PR TITLE
Fetaure/madatory settings

### DIFF
--- a/automatilib/cola/views.py
+++ b/automatilib/cola/views.py
@@ -7,6 +7,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.base_user import AbstractBaseUser
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -15,6 +16,18 @@ from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
 
 LOGGER = logging.getLogger(__name__)
+
+SETTINGS = (
+    "AWS_REGION_NAME",
+    "COLA_COGNITO_USER_POOL_ID",
+    "COLA_COOKIE_NAME",
+    "COLA_JWT_EXTRACTION_REGEX_PATTERN",
+    "LOGIN_REDIRECT_URL",
+    "LOGIN_URL",
+)
+for key in SETTINGS:
+    if not getattr(settings, key):
+        raise ImproperlyConfigured(f"{key} must be set")
 
 
 COLA_ISSUER = f"https://cognito-idp.{settings.AWS_REGION_NAME}.amazonaws.com/{settings.COLA_COGNITO_USER_POOL_ID}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ extend-ignore = ["E203", "W503", "E231", "N804", "N805", "E731", "N815"]
 
 [tool.poetry]
 name = "automatilib"
-version = "0.2.1"
+version = "0.3.1"
 authors = ["i.AI <i-dot-ai-team@cabinetoffice.gov.uk>"]
 maintainers = ["i.AI <i-dot-ai-team@cabinetoffice.gov.uk>"]
 license = "BSD"


### PR DESCRIPTION
The settings are now mandatory.

Previously it was possible that the `AWS_REGION_NAME` could be null which would lead to mall-formed urls.