### PR TITLE
feature/delete cookie on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It provides common features used in many of our applications.
 * `LOGIN_URL` - The URL to redirect users to if they are not logged in
 * `COLA_COOKIE_NAME` - The name of the cookie to check for COLA JWT
 * `COLA_COGNITO_CLIENT_ID` - The cognito client ID found in AWS
+* `COLA_LOGIN_FAILURE` - Where the user should be redirected to in the event of authentication failure.
 * `AWS_REGION_NAME` - The AWS region that the user pool and cognito client live in
 * `COLA_COGNITO_USER_POOL_ID` - The cognito user pool ID in AWS
 
@@ -29,6 +30,7 @@ This is where some of the above can be found:
 * `COLA_COGNITO_USER_POOL_ID`: In AWS, go to your cognito user pool, in the top table called `User pool overview`, your `User pool ID` is there
 * `COLA_LOGIN_URL`: Ask the COLA team for this URL
 * `COLA_JWT_REGEX_PATTERN`: This is one you can adjust how you want to, the baseline is `(?<=:).*(?=\.)`
+* `COLA_LOGIN_FAILURE` - This should be a route in your app, if not specified the user will get a raw 401 plain text message.
 
 
 ## To make use of COLA

--- a/automatilib/cola/views.py
+++ b/automatilib/cola/views.py
@@ -7,7 +7,12 @@ from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpRequest, HttpResponse
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponsePermanentRedirect,
+    HttpResponseRedirect,
+)
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
@@ -90,7 +95,9 @@ class ColaLogin(View):
         """
         pass
 
-    def get(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+    def get(
+        self, request: HttpRequest, **kwargs: dict
+    ) -> HttpResponse | HttpResponseRedirect | HttpResponsePermanentRedirect:
         if request.user and request.user.is_authenticated:
             return redirect(reverse(settings.LOGIN_REDIRECT_URL))
 

--- a/automatilib/cola/views.py
+++ b/automatilib/cola/views.py
@@ -7,12 +7,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.core.exceptions import ImproperlyConfigured
-from django.http import (
-    HttpRequest,
-    HttpResponse,
-    HttpResponsePermanentRedirect,
-    HttpResponseRedirect,
-)
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
@@ -95,9 +90,7 @@ class ColaLogin(View):
         """
         pass
 
-    def get(
-        self, request: HttpRequest, **kwargs: dict
-    ) -> HttpResponse | HttpResponseRedirect | HttpResponsePermanentRedirect:
+    def get(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         if request.user and request.user.is_authenticated:
             return redirect(reverse(settings.LOGIN_REDIRECT_URL))
 

--- a/automatilib/cola/views.py
+++ b/automatilib/cola/views.py
@@ -130,10 +130,14 @@ class ColaLogin(View):
                     "require_sub": True,
                 },
             )
-
         except (ExpiredSignatureError, JWTClaimsError, JWTError) as error:
             LOGGER.error(f"cookie error: {error}")
-            return HttpResponse("Unauthorized", status=401)
+            if getattr(settings, "COLA_LOGIN_FAILURE", None) is not None:
+                http_response = redirect(reverse(settings.LOGIN_FAILURE), status=401)
+            else:
+                http_response = HttpResponse("Unauthorized", status=401)
+            http_response.delete_cookie(settings.COLA_COOKIE_NAME)
+            return http_response
 
         authenticated_user = {
             "email": payload["email"],

--- a/automatilib/cola/views.py
+++ b/automatilib/cola/views.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from typing import Union
 from urllib.parse import unquote
 
 import requests
@@ -97,7 +98,7 @@ class ColaLogin(View):
 
     def get(
         self, request: HttpRequest, **kwargs: dict
-    ) -> HttpResponse | HttpResponseRedirect | HttpResponsePermanentRedirect:
+    ) -> Union[HttpResponse, HttpResponseRedirect, HttpResponsePermanentRedirect]:
         if request.user and request.user.is_authenticated:
             return redirect(reverse(settings.LOGIN_REDIRECT_URL))
 
@@ -140,7 +141,7 @@ class ColaLogin(View):
         except (ExpiredSignatureError, JWTClaimsError, JWTError) as error:
             LOGGER.error(f"cookie error: {error}")
             if getattr(settings, "COLA_LOGIN_FAILURE", None) is not None:
-                permanent_redirect = redirect(reverse(settings.LOGIN_FAILURE), status=401)
+                permanent_redirect = redirect(reverse(settings.COLA_LOGIN_FAILURE), status=401)
                 permanent_redirect.delete_cookie(settings.COLA_COOKIE_NAME)
                 return permanent_redirect
 

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -6,5 +6,5 @@ from example_project import views
 urlpatterns = [
     path("hello/", views.hello_world, name="hello-world"),
     path("my_account/", views.my_account, name="my-account"),
-    path("/login-failure", views.login_failure, name="login-failure"),
+    path("login-failure/", views.login_failure, name="login-failure"),
 ] + cola_urls

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -6,4 +6,5 @@ from example_project import views
 urlpatterns = [
     path("hello/", views.hello_world, name="hello-world"),
     path("my_account/", views.my_account, name="my-account"),
+    path("/login-failure", views.login_failure, name="login-failure"),
 ] + cola_urls

--- a/example_project/views.py
+++ b/example_project/views.py
@@ -10,3 +10,7 @@ def hello_world(request):
 @login_required
 def my_account(request):
     return HttpResponse(f"welcome back {request.user.email}")
+
+
+def login_failure(_):
+    return HttpResponse("go away!", status=401)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ extend-ignore = ["E203", "W503", "E231", "N804", "N805", "E731", "N815"]
 
 [tool.poetry]
 name = "automatilib"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["i.AI <i-dot-ai-team@cabinetoffice.gov.uk>"]
 maintainers = ["i.AI <i-dot-ai-team@cabinetoffice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Should the JWT verification fail then the cookie is now deleted. This way the user is forced to regenerate the cookie.

Out of scope:
* default error page
* making the `COLA_LOGIN_FAILURE` setting mandatory  as this will introduce backwards incompatibility at a time where we need stability